### PR TITLE
Fixed syntax highlighting

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -129,23 +129,22 @@ export class Parser {
     return tokens;
   }
 
-  private highlight(code: string, lang: string, callback?: (error: any | undefined, code?: string) => void) {
-    if (!callback) {
-      throw new Error('No callback provided');
-    }
+  private highlight(code: string, lang: string, callback?: (error: any | undefined, code?: string) => void) : string | void {
 
-    if (!lang || !hljs.getLanguage(lang)) {
-      callback(null, code);
-      return;
+    let result = null;
+    if (lang && hljs.getLanguage(lang)) {
+      try {
+        const temp = hljs.highlight(code, { language: lang });
+        result = temp.value;
+      } catch {
+        result = code;
+      }
     }
-
-    try {
-      const result = hljs.highlight(code, { language: lang });
-      callback(null, result.value);
-    } catch {
-      callback(null, code);
-      return;
-    }
+   
+    if (callback)
+      callback(null, result);
+    else
+      return result;
   }
 
   private renderLink(href: string | null, title: string | null, text: string): string {

--- a/test/test-json.md
+++ b/test/test-json.md
@@ -1,0 +1,41 @@
+# Settings
+
+Demo for syntax highlighting
+
+```json
+...
+"items" : [
+    {
+        "name":"sampleName",
+        "type":"string",
+        "label":"MeasurementResources.SampleName"
+    },
+    {
+        "name":"power",
+        "type":"double",
+        "label":"MeasurementResources.Power"
+    },
+    {
+        "name":"coolGasFlow",
+        "type":"double",
+        "label":"MeasurementResources.CoolGasFlow"
+    },        
+    {
+        "name":"pumpEnabled",
+        "type":"toggle",
+        "label":"MeasurementResources.EnablePump"
+    },
+    {
+        "name":"nebulizerType",
+        "type":"dropdown",
+        "label":"MeasurementResources.NeublizerType",
+        "valueType" : "integer",
+        "options": [
+            { "key": 0, text:"MeasurementResources.NebulizerTypeA" },
+            { "key": 1, text:"MeasurementResources.NebulizerTypeB" },
+            { "key": 2, text:"MeasurementResources.NebulizerTypeC" }
+        ]
+    }
+]
+...
+```


### PR DESCRIPTION
Seems that syntax highlighting got broken, I guess because of my change to use the synchronous marked API.
Adapted highlight function to use either a callback when given, or otherwise returning the result directly. Added test file.